### PR TITLE
🐛 Avoid timeout errors

### DIFF
--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -8,8 +8,8 @@ defmodule MixTestInteractive do
   @doc """
   Start the interactive test runner.
   """
-  @spec run([String.t()]) :: :ok
-  def run(args \\ []) when is_list(args) do
+  @spec run([String.t()]) :: no_return()
+  def(run(args \\ []) when is_list(args)) do
     Mix.env(:test)
     {:ok, _} = Application.ensure_all_started(:mix_test_interactive)
 
@@ -19,10 +19,7 @@ defmodule MixTestInteractive do
 
   defp loop do
     command = IO.gets("")
-
-    case InteractiveMode.process_command(command) do
-      :quit -> :ok
-      :ok -> loop()
-    end
+    InteractiveMode.process_command(command)
+    loop()
   end
 end

--- a/test/mix_test_interactive/end_to_end_test.exs
+++ b/test/mix_test_interactive/end_to_end_test.exs
@@ -58,8 +58,6 @@ defmodule MixTestInteractive.EndToEndTest do
 
     assert :ok = InteractiveMode.note_file_changed(pid)
     assert_ran_tests(["--stale"])
-
-    assert :quit = InteractiveMode.process_command(pid, "q")
   end
 
   defp assert_ran_tests(args \\ []) do


### PR DESCRIPTION
Fixes #43 

When a command is entered during a long test run, a GenServer timeout would be raised.

To fix this, `InteractiveMode.process_command` now uses `cast` instead of `call` so that the read loop doesn't block on commands.

To make this work, we now have to use `System.stop` for the `quit` command rather than returning a `:quit` atom and allowing the loop to exit naturally.

`System.stop` takes just enough time that it seems like the quit command was ignored, so I also added a `Shutting down...` message to make it clear that something is happening.