### PR TITLE
🐛 Fix `p` command for umbrella projects

### DIFF
--- a/lib/mix_test_interactive/test_files.ex
+++ b/lib/mix_test_interactive/test_files.ex
@@ -12,9 +12,17 @@ defmodule MixTestInteractive.TestFiles do
   @spec list() :: [String.t()]
   def list() do
     config = Mix.Project.config()
-    paths = config[:test_paths] || ["test"]
+    paths = config[:test_paths] || default_test_paths()
     pattern = config[:test_pattern] || "*_test.exs"
 
     Mix.Utils.extract_files(paths, pattern)
+  end
+
+  def default_test_paths do
+    if Mix.Project.umbrella?() do
+      Path.wildcard("apps/*/test")
+    else
+      ["test"]
+    end
   end
 end


### PR DESCRIPTION
In an umbrella project, the `p` (pattern) command was not matching any files.

This happened because it uses `test` as the default path to find files to match, which doesn't exist in an umbrella project.

With this change, we detect an umbrella project and in that case, wildcard-match the `test` directories of all of the apps in the umbrella.

It is still possible to specify the `:test_paths` config option for `mix test`. If that config setting is present, `mix test.interactive` will use that setting and not default to the wildcard setting.